### PR TITLE
Ctrl Delete in VS also deletes the spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,11 @@
                 "key": "shift+enter",
                 "command": "editor.action.insertLineAfter",
                 "when": "editorTextFocus && !editorReadonly"
+            },
+            {
+                "key": "ctrl+delete",
+                "command": "deleteWordStartRight",
+                "when": "editorTextFocus && !editorReadonly"
             }
         ]
     },


### PR DESCRIPTION
In Visual Studio, Ctrl Delete deletes up 'til the next word. In Visual Studio Code, it deletes to the end of the current word.

To see the difference, try ctrl delete when the caret is in the first word of the following example:
```
foo          bar
```
