### PR TITLE
Clearing column selection on arrow keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,36 @@
                 "when": "editorTextFocus"
             },
             {
+                "key": "left",
+                "command": "cancelSelection",
+                "when": "editorHasMultipleSelections && textInputFocus"
+            },
+            {
+                "key": "right",
+                "command": "cancelSelection",
+                "when": "editorHasMultipleSelections && textInputFocus"
+            },
+            {
+                "key": "up",
+                "command": "cancelSelection",
+                "when": "editorHasMultipleSelections && textInputFocus"
+            },
+            {
+                "key": "down",
+                "command": "cancelSelection",
+                "when": "editorHasMultipleSelections && textInputFocus"
+            },
+            {
+                "key": "pageup",
+                "command": "cancelSelection",
+                "when": "editorHasMultipleSelections && textInputFocus"
+            },
+            {
+                "key": "pagedown",
+                "command": "cancelSelection",
+                "when": "editorHasMultipleSelections && textInputFocus"
+            },
+            {
                 "key": "shift+alt+enter",
                 "command": "workbench.action.toggleZenMode"
             },


### PR DESCRIPTION
When column selection is made (using Ctrl+Shift+<arrow/mice>), using arrow keys moves all the cursors together (i.e. if you selected 10 lines, you are moving 10 cursors) instead of cancelling selection.

These key bindings ensure that selection is cleared on arrow key same as Visual Studio does.