### PR TITLE
Update selection bindings (Ctrl+W & Shift+Alt+.)

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,11 +78,13 @@
             },
             {
                 "key": "ctrl+w",
-                "command": "editor.action.smartSelect.expand"
+                "command": "editor.action.smartSelect.expand",
+                "when": "editorTextFocus"
             },
             {
                 "key": "shift+alt+.",
-                "command": "editor.action.addSelectionToNextFindMatch"
+                "command": "editor.action.addSelectionToNextFindMatch",
+                "when": "editorFocus"
             },
             {
                 "key": "ctrl+alt+space",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,10 @@
             },
             {
                 "key": "ctrl+w",
+                "command": "editor.action.smartSelect.expand"
+            },
+            {
+                "key": "shift+alt+.",
                 "command": "editor.action.addSelectionToNextFindMatch"
             },
             {


### PR DESCRIPTION
### Change "Ctrl+W" binding to "Expand Selection"

This is to match [Visual Studio keyboard shortcut for "Edit.SelectCurrentWord"](https://docs.microsoft.com/en-us/visualstudio/ide/default-keyboard-shortcuts-in-visual-studio?view=vs-2019#text-editor)

![image](https://user-images.githubusercontent.com/10026538/61975315-b2465680-afe0-11e9-8a3a-785a24844b92.png)


### Set "Shift+Alt+." to "Add Selection To Next Find Match"

This is to match [Visual Studio keyboard shortcut for "Edit.InsertNextMatchingCaret"](https://docs.microsoft.com/en-us/visualstudio/ide/default-keyboard-shortcuts-in-visual-studio?view=vs-2019#text-editor)

![image](https://user-images.githubusercontent.com/10026538/61976434-b031c700-afe3-11e9-9e14-5fccca7f36f1.png)

