### PR TITLE
Keybinding for matching bracket "ctrl+]"

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,6 +259,11 @@
                 "key": "ctrl+delete",
                 "command": "deleteWordStartRight",
                 "when": "editorTextFocus && !editorReadonly"
+            },
+            {
+                "key": "ctrl+]",
+                "command": "editor.action.jumpToBracket",
+                "when": "editorTextFocus"
             }
         ]
     },


### PR DESCRIPTION
Change VS Code's default keybinding from "ctrl+shift+\" to Visual studio's "ctrl+]" to move cursor to matching bracket.