### PR TITLE
Add "Keep Tab Open" shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,8 +258,12 @@
                 "key": "ctrl+delete",
                 "command": "deleteWordStartRight",
                 "when": "editorTextFocus && !editorReadonly"
+            },
+            {
+                "key": "ctrl+alt+home",
+                "command": "workbench.action.keepEditor",
+                "when": "editorTextFocus"
             }
         ]
-
     }
 }


### PR DESCRIPTION
Visual Studio can open files in a temporary/preview tab that is replaced when previewing another file, "ctrl + alt + home" allows to keep the tab open.

Available in `Window` > `Keep Tab Open` or via right-click on a tab.